### PR TITLE
fix: jsonc code block in markdown does not have syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 ## [unreleased]
 
 - new feature: provided examples fom examples folder are validated against current generated JSON schema
+- fix: jsonc code block in markdown does not have syntax highlighting, replaced by json code block instead
 
 ## [0.5.0]
 

--- a/src/__snapshots__/generateExampleDocumentation.test.ts.snap
+++ b/src/__snapshots__/generateExampleDocumentation.test.ts.snap
@@ -4,7 +4,7 @@ exports[`test generateExampleDocumentation should generate md files for .json an
 "This is an example introduction for example1.
 ## Example File:  example1
 
-\`\`\`jsonc
+\`\`\`json
 {
             // this is a comment in jsonc
             "firstName": "John",

--- a/src/__tests__/__snapshots__/cli-docs-config.test.ts.snap
+++ b/src/__tests__/__snapshots__/cli-docs-config.test.ts.snap
@@ -8,7 +8,7 @@ description: Example documents for my-spec.
 
 ## Example File:  example1
 
-\`\`\`jsonc
+\`\`\`json
 {
             // this is a comment in jsonc
             "firstName": "John",
@@ -36,7 +36,7 @@ exports[`CLI docsConfig tests Test the docsConfig Test the SpecConfig examplesFo
 "This is an example introduction for example1.
 ## Example File:  example1
 
-\`\`\`jsonc
+\`\`\`json
 {
             // this is a comment in jsonc
             "firstName": "John",
@@ -94,7 +94,7 @@ description: Example documents for my-spec.
 
 ## Example File:  example1
 
-\`\`\`jsonc
+\`\`\`json
 {
             // this is a comment in jsonc
             "firstName": "John",
@@ -112,7 +112,7 @@ description: Example documents for my-spec.
 
 ## Example File:  example2
 
-\`\`\`jsonc
+\`\`\`json
 {
             // this is a second comment in jsonc
             "firstName": "Jane",

--- a/src/generateExampleDocumentation.ts
+++ b/src/generateExampleDocumentation.ts
@@ -93,7 +93,7 @@ export function generateExampleDocumentation(configData: SpecToolkitConfiguratio
           text += `---\n\n`;
         }
         text += `## Example File:  ${title}\n\n`;
-        text += filePath.includes(".jsonc") ? "```jsonc\n" : "```json\n";
+        text += "```json\n";
         text += exampleFileContent;
         text += "\n```\n";
         if (exampleFileOutroContent) {


### PR DESCRIPTION
closes https://github.com/open-resource-discovery/spec-toolkit/issues/15