### PR TITLE
bump version to v.0.7.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Installing Node.js
         uses: actions/setup-node@v4
@@ -37,7 +37,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -59,7 +59,7 @@ jobs:
     name: Build job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -77,7 +77,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -33,6 +33,9 @@ jobs:
           # registry-url is required for releasing packages
           registry-url: ${{ vars.NPM_REGISTRY }}
 
+      - name: Install latest npm cli # TODO: can be removed when updating to node 24, npm v.11 is needed for npm trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
@@ -41,9 +44,7 @@ jobs:
 
       - name: Publish to NPM
         # --access public is only hard required for the initial release, but it doesn't hurt having it setup
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
   githubRelease:
     needs: [npm]
@@ -55,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+## [0.7.0]
+
 - breaking: deleted `x-hide-properties`, remove it from JSON schema if used
 - breaking: renamed `x-hide-property` to new `x-hide` which can be placed now on object property level and entity definition level
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-resource-discovery/spec-toolkit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-resource-discovery/spec-toolkit",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/package",
   "name": "@open-resource-discovery/spec-toolkit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "JSON Schema Toolkit CLI to create schema based interface documentation",
   "author": "SAP SE",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bump version to v.0.7.0
- Enable trusted publishing channel to NPM registry -> remove NPM registry token
- Update GH Actions versions of checkout & node-setup actions