### PR TITLE
WIP: tolerant mode for arbitrary JSON Schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ For a roadmap including expected timeline, please refer to [ROADMAP.md](./ROADMA
 
 ## [unreleased]
 
+- new feature: tolerant mode for arbitrary JSON Schemas. The Markdown documentation generator no longer rejects schemas that break the strong authoring conventions; instead it normalizes them and warns. Specifically:
+  - inline nested objects and inline `oneOf`/`anyOf`/`allOf` branches that carry a shape are virtually hoisted into `#/definitions` (in memory; the authored file is never modified) via a new `normalizeArbitrarySchema` pass;
+  - a node that has object keywords (`properties`/`patternProperties`/`additionalProperties`) but no `type` is treated as `type: object`;
+  - `allOf` `if`/`then` conditionals expressing conditional requiredness are surfaced as a note rather than erroring;
+  - a node with no recognizable construct is rendered as a free-form value instead of throwing.
+  Schemas already authored to the conventions pass through unchanged (no output differences).
+- fix: TypeScript type generation for a single schema that `json-schema-to-typescript` cannot handle (e.g. inline `if`/`then`/`else` conditionals) is now skipped with a warning instead of aborting the whole run; the Markdown documentation is still produced.
+- fix: the ajv draft-07 meta-schema is resolved relative to the installed `ajv` package (via `require.resolve`) instead of a hardcoded `./node_modules/ajv/...` path, so the tool works regardless of the current working directory.
+- fix: absolute `-c` config paths and absolute `sourceFilePath` values are honored as-is (`path.resolve` instead of `path.join(process.cwd(), ...)`), while relative paths remain CWD-relative (backward compatible).
+- fix: non-conventional `$ref` shapes are reported as warnings rather than hard errors, since the normalization pass rewrites arbitrary schemas into the conventional `#/definitions/<name>` form first.
+
 ## [0.8.1]
 
 - fix: deduplicate `customTypeDefinitions` by name when merging, so shared referenced types (e.g. `Labels`) are only registered once even when multiple nested custom types reference the same definition

--- a/src/__tests__/cli-e2e.test.ts
+++ b/src/__tests__/cli-e2e.test.ts
@@ -124,4 +124,34 @@ describe("CLI End-to-End Tests", () => {
       expect(e).toEqual("expect this to never happen because above code should not throw an error");
     }
   });
+
+  // Tolerant mode: a deliberately non-convention-clean schema (inline nested
+  // objects, an inline oneOf branch, a node missing `type`, and an allOf
+  // if/then conditional) MUST still generate documentation. Deviations are
+  // warned about (stderr is not required to be empty), TypeScript type
+  // generation for the conditional schema is skipped, and the run succeeds.
+  test("test 5: tolerant run with a non-convention-clean schema still generates docs", async () => {
+    const configFile = "./src/__tests__/testData/valid/test5-my-tolerant-spec-config.json";
+    const cliArguments = [cliScriptPath, "-c", configFile];
+
+    const { stdout } = await spawnAsync(cliBin, cliArguments);
+
+    expect(stdout).toContain(
+      "SUCCESS: Documentation successfully generated to src/__tests__/generated/test5/my-tolerant-spec-v1",
+    );
+    // Normalization warnings are surfaced rather than causing a failure.
+    expect(stdout).toContain("Normalized:");
+    // TypeScript type generation for the conditional schema is skipped, not fatal.
+    expect(stdout).toContain("Skipping TypeScript type generation");
+
+    const mdFileContent = fs
+      .readFileSync("src/__tests__/generated/test5/my-tolerant-spec-v1/docs/my-tolerant-spec.md")
+      .toString();
+    // Inline nested objects were hoisted into linked definitions.
+    expect(mdFileContent).toContain("[Metadata](#metadata)");
+    expect(mdFileContent).toContain("### Target");
+    // The allOf if/then conditional is surfaced as a note.
+    expect(mdFileContent).toContain("conditional requirements");
+    expect(mdFileContent).toMatchSnapshot();
+  });
 });

--- a/src/__tests__/testData/valid/test5-my-tolerant-spec-config.json
+++ b/src/__tests__/testData/valid/test5-my-tolerant-spec-config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://open-resource-discovery.github.io/spec-toolkit/spec-v1/spec-toolkit-config.schema.json#",
+  "outputPath": "src/__tests__/generated/test5/my-tolerant-spec-v1",
+  "docsConfig": [
+    {
+      "type": "spec",
+      "id": "my-tolerant-spec",
+      "sourceFilePath": "./src/__tests__/testData/valid/test5-my-tolerant-spec.schema.yaml"
+    }
+  ]
+}

--- a/src/__tests__/testData/valid/test5-my-tolerant-spec.schema.yaml
+++ b/src/__tests__/testData/valid/test5-my-tolerant-spec.schema.yaml
@@ -1,0 +1,61 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://example.com/my-tolerant-spec.schema.json
+title: My Tolerant Spec
+description: >
+  A deliberately non-convention-clean schema that exercises spec-toolkit's
+  tolerant mode: inline nested objects, an inline oneOf branch, a node missing
+  its `type`, and an allOf if/then conditional (conditional requiredness).
+type: object
+required:
+  - name
+  - target
+properties:
+  name:
+    type: string
+    description: The resource name.
+  # Inline nested object (no $ref) -> should be virtually hoisted.
+  metadata:
+    type: object
+    description: Free-form metadata about the resource.
+    properties:
+      owner:
+        type: string
+      labels:
+        type: object
+        additionalProperties:
+          type: string
+  # Object keywords but missing `type` -> should be assumed object, then hoisted.
+  config:
+    properties:
+      timeoutSeconds:
+        type: integer
+  # Inline (non-$ref) oneOf branches -> object branch hoisted, primitive left inline.
+  value:
+    description: A string shorthand or a structured value.
+    oneOf:
+      - type: string
+      - type: object
+        properties:
+          amount:
+            type: number
+  target:
+    type: object
+    description: What is executed.
+    properties:
+      type:
+        type: string
+        enum:
+          - agent
+          - api
+      id:
+        type: string
+    # allOf if/then conditional (conditional requiredness) -> rendered as a note,
+    # NOT hoisted, and TypeScript type generation for it is skipped with a warning.
+    allOf:
+      - if:
+          properties:
+            type:
+              const: agent
+        then:
+          required:
+            - id

--- a/src/cliRunner.ts
+++ b/src/cliRunner.ts
@@ -4,7 +4,7 @@ import { Ajv, type Schema } from "ajv";
 import addFormats from "ajv-formats";
 import { Command, Option } from "commander";
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import * as packageJson from "../package.json" with { type: "json" };
 import { generate } from "./generate.js";
 import type { SpecToolkitConfigurationDocument } from "./generated/spec-toolkit-config/spec-v1/types/index.js";
@@ -39,7 +39,10 @@ function init(argv: string[]): void {
 
 async function run(argv: CliOptions): Promise<void> {
   let configData: unknown;
-  const configFilePath = path.join(process.cwd(), argv.config);
+  // Use path.resolve so an ABSOLUTE `-c` path is honored as-is; a relative path
+  // still resolves against the current working directory (backward compatible).
+  // Previously path.join(cwd, argv.config) mangled absolute paths.
+  const configFilePath = path.resolve(process.cwd(), argv.config);
 
   try {
     if (configFilePath.endsWith(".json")) {

--- a/src/generateInterfaceDocumentation.ts
+++ b/src/generateInterfaceDocumentation.ts
@@ -11,7 +11,7 @@
 
 import path from "node:path";
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import {
   documentationExtensionsOutputFolderName,
   documentationOutputFolderName,
@@ -30,6 +30,7 @@ import {
 } from "./util/jsonSchemaConversion.js";
 import { log } from "./util/log.js";
 import { getMarkdownFrontMatter } from "./util/markdownTextHelper.js";
+import { normalizeArbitrarySchema } from "./util/normalizeArbitrarySchema.js";
 import { validateSpecJsonSchema } from "./util/validation.js";
 
 ////////////////////////////////////////////////////////////
@@ -66,13 +67,27 @@ export interface DocumentationResult {
 export function jsonSchemaToDocumentation(configData: SpecToolkitConfigurationDocument): void {
   // Iterate the files and generate the documentation
   for (const docConfig of configData.docsConfig) {
-    // Read JSON File
-    const jsonSchemaFile = fs.readFileSync(path.join(process.cwd(), docConfig.sourceFilePath)).toString();
+    // Read JSON File. path.resolve honors an absolute sourceFilePath as-is; a
+    // relative one still resolves against the current working directory.
+    const jsonSchemaFile = fs.readFileSync(path.resolve(process.cwd(), docConfig.sourceFilePath)).toString();
     // TODO: validate here before casting it as SpecJsonSchemaRoot, or probably even better validate outside of the for loop
     const jsonSchemaFileParsed = yaml.load(jsonSchemaFile) as SpecJsonSchemaRoot;
 
     // The Spec JSON Schema based Specification
-    const jsonSchemaRoot = preprocessSpecJsonSchema(jsonSchemaFileParsed);
+    let jsonSchemaRoot = preprocessSpecJsonSchema(jsonSchemaFileParsed);
+
+    // Tolerant mode: normalize arbitrary JSON Schemas into the shape the
+    // renderer and validator expect (hoist inline objects and inline
+    // composition branches into #/definitions, add missing object `type`),
+    // warning on each rewrite instead of rejecting the schema. Schemas already
+    // authored to the conventions pass through unchanged.
+    const normalized = normalizeArbitrarySchema(jsonSchemaRoot);
+    jsonSchemaRoot = normalized.schema;
+    if (normalized.warnings.length > 0) {
+      log.warn(
+        `${docConfig.sourceFilePath}: ${normalized.warnings.length} schema normalization(s) applied for documentation generation (see warnings above).`,
+      );
+    }
     log.info(`${docConfig.sourceFilePath} loaded and prepared.`);
 
     // Read extension target file if given

--- a/src/generateTypeScriptDefinitions.ts
+++ b/src/generateTypeScriptDefinitions.ts
@@ -1,5 +1,5 @@
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import type { JSONSchema4 } from "json-schema";
 import { compile as jsonSchemaToTypeScript } from "json-schema-to-typescript";
 import { schemasOutputFolderName, typesOutputFolderName } from "./generate.js";
@@ -25,73 +25,90 @@ export async function generateTypeScriptDefinitions(configData: SpecToolkitConfi
     if (docConfig.type === "spec") {
       const xSchemaFileName = `${docConfig.id}.schema.json`.split(".json").join(".x.json");
       const xSchemaFilePath = `${configData.outputPath}/${schemasOutputFolderName}/${xSchemaFileName}`;
-      let schema = yaml.load(fs.readFileSync(`${xSchemaFilePath}`).toString()) as SpecJsonSchemaRoot;
+      try {
+        let schema = yaml.load(fs.readFileSync(`${xSchemaFilePath}`).toString()) as SpecJsonSchemaRoot;
 
-      schema = convertRefToDocToStandardRef(schema);
-      schema = convertOneOfEnum(schema);
-      schema = convertAnyOfEnum(schema);
-      schema = convertAllOfWithIfThenDiscriminatorToOneOf(schema);
+        schema = convertRefToDocToStandardRef(schema);
+        schema = convertOneOfEnum(schema);
+        schema = convertAnyOfEnum(schema);
+        schema = convertAllOfWithIfThenDiscriminatorToOneOf(schema);
 
-      // Schema cleaned up
-      schema = removeDescriptionsFromRefPointers(schema);
-      const allCustomPropertiesTypescriptTypes = schema["x-custom-typescript-types"];
+        // Schema cleaned up
+        schema = removeDescriptionsFromRefPointers(schema);
+        const allCustomPropertiesTypescriptTypes = schema["x-custom-typescript-types"];
 
-      // Remove x- properties that are not relevant for end spec consumers
-      // But if this is the case when spec-toolkit self documents it's own spec schema,
-      // we want to keep all x- properties as part of the generated documentation
-      if (!schema.$id?.includes("spec.schema.json") && !schema.title?.includes("Spec Json Schema Root")) {
-        schema = removeAllExtensionProperties(schema);
-      }
-
-      const convertedDocumentSchema = schema as unknown as JSONSchema4;
-
-      let definitions = await jsonSchemaToTypeScript(convertedDocumentSchema, `${docConfig.id}`, {
-        unknownAny: true,
-        bannerComment: "// AUTO-GENERATED definition files. Do not modify directly.\n\n",
-        strictIndexSignatures: true,
-        declareExternallyReferenced: true,
-        inferStringEnumKeysFromValues: false,
-      });
-
-      // Clean up unnecessary "This interface was referenced..." mentions
-      definitions = definitions.replace(/ {3}\*\n {3}\* This interface was referenced by (.*)\n(.*)\n/gm, "");
-
-      // Add export of custom defined x-custom-typescript-types
-      if (allCustomPropertiesTypescriptTypes) {
-        for (const xPatternPropertiesTypescriptTypes of allCustomPropertiesTypescriptTypes) {
-          definitions +=
-            `\nexport type ${xPatternPropertiesTypescriptTypes.typeName} = ` +
-            `${xPatternPropertiesTypescriptTypes.typeValue}` +
-            `;\n`;
+        // Remove x- properties that are not relevant for end spec consumers
+        // But if this is the case when spec-toolkit self documents it's own spec schema,
+        // we want to keep all x- properties as part of the generated documentation
+        if (!schema.$id?.includes("spec.schema.json") && !schema.title?.includes("Spec Json Schema Root")) {
+          schema = removeAllExtensionProperties(schema);
         }
-      }
 
-      // Post processing for all tsType "// replaceKeyType_" markings
-      const allPostProcessingReplacements: { oldValue: string; newValue: string }[] = [];
-      const allPostProcessingReplacementMatches = [...definitions.matchAll(/.*replaceKeyType_{(.*)}/gm)];
-      for (const match of allPostProcessingReplacementMatches) {
-        const replacementNewValue = `${match[0].replace("string", match[1]).split(";")[0]};`;
-        const indexStart = match.index;
-        const indexEnd = match.index + match[0].length;
-        allPostProcessingReplacements.push({
-          oldValue: definitions.substring(indexStart, indexEnd),
-          newValue: replacementNewValue,
+        const convertedDocumentSchema = schema as unknown as JSONSchema4;
+
+        let definitions = await jsonSchemaToTypeScript(convertedDocumentSchema, `${docConfig.id}`, {
+          unknownAny: true,
+          bannerComment: "// AUTO-GENERATED definition files. Do not modify directly.\n\n",
+          strictIndexSignatures: true,
+          declareExternallyReferenced: true,
+          inferStringEnumKeysFromValues: false,
         });
-      }
-      for (const replacement of allPostProcessingReplacements) {
-        definitions = definitions.replace(replacement.oldValue, replacement.newValue);
-      }
 
-      fs.unlinkSync(xSchemaFilePath);
-      log.info(`Cleanup temporary file ${xSchemaFilePath}`);
+        // Clean up unnecessary "This interface was referenced..." mentions
+        definitions = definitions.replace(/ {3}\*\n {3}\* This interface was referenced by (.*)\n(.*)\n/gm, "");
 
-      const typesFile = `${process.cwd()}/${configData.outputPath}/${typesOutputFolderName}/${docConfig.id}.ts`;
-      await fs.outputFile(typesFile, definitions);
-      log.info(`Result: ${typesFile}`);
-      if (configData.generalConfig?.tsTypeExportExcludeJsFileExtension) {
-        indexExportStatements += `export * from "./${docConfig.id}";\n`;
-      } else {
-        indexExportStatements += `export * from "./${docConfig.id}.js";\n`;
+        // Add export of custom defined x-custom-typescript-types
+        if (allCustomPropertiesTypescriptTypes) {
+          for (const xPatternPropertiesTypescriptTypes of allCustomPropertiesTypescriptTypes) {
+            definitions +=
+              `\nexport type ${xPatternPropertiesTypescriptTypes.typeName} = ` +
+              `${xPatternPropertiesTypescriptTypes.typeValue}` +
+              `;\n`;
+          }
+        }
+
+        // Post processing for all tsType "// replaceKeyType_" markings
+        const allPostProcessingReplacements: { oldValue: string; newValue: string }[] = [];
+        const allPostProcessingReplacementMatches = [...definitions.matchAll(/.*replaceKeyType_{(.*)}/gm)];
+        for (const match of allPostProcessingReplacementMatches) {
+          const replacementNewValue = `${match[0].replace("string", match[1]).split(";")[0]};`;
+          const indexStart = match.index;
+          const indexEnd = match.index + match[0].length;
+          allPostProcessingReplacements.push({
+            oldValue: definitions.substring(indexStart, indexEnd),
+            newValue: replacementNewValue,
+          });
+        }
+        for (const replacement of allPostProcessingReplacements) {
+          definitions = definitions.replace(replacement.oldValue, replacement.newValue);
+        }
+
+        fs.unlinkSync(xSchemaFilePath);
+        log.info(`Cleanup temporary file ${xSchemaFilePath}`);
+
+        const typesFile = `${process.cwd()}/${configData.outputPath}/${typesOutputFolderName}/${docConfig.id}.ts`;
+        await fs.outputFile(typesFile, definitions);
+        log.info(`Result: ${typesFile}`);
+        if (configData.generalConfig?.tsTypeExportExcludeJsFileExtension) {
+          indexExportStatements += `export * from "./${docConfig.id}";\n`;
+        } else {
+          indexExportStatements += `export * from "./${docConfig.id}.js";\n`;
+        }
+      } catch (err) {
+        // Tolerant mode: TypeScript type generation via json-schema-to-typescript
+        // cannot always handle arbitrary JSON Schema (e.g. inline if/then/else
+        // conditionals). Warn and skip the TS types for this schema rather than
+        // aborting the whole run — the Markdown interface docs (already written)
+        // are the primary artifact and are unaffected.
+        log.warn(
+          `Skipping TypeScript type generation for "${docConfig.id}": ${(err as Error).message}. The Markdown documentation was still generated.`,
+        );
+        // Best-effort cleanup of the temporary x-schema file.
+        try {
+          if (fs.existsSync(xSchemaFilePath)) fs.unlinkSync(xSchemaFilePath);
+        } catch {
+          // ignore
+        }
       }
     }
   }

--- a/src/markdown/generateMarkdownUtils.ts
+++ b/src/markdown/generateMarkdownUtils.ts
@@ -57,14 +57,27 @@ export function jsonSchemaToMd(
     text += `${jsonSchemaObject.description.trim()}\n\n`;
   }
   const castedJsonSchemaObject = jsonSchemaObject as SpecExtensionJsonSchema;
-  // Distinction if this is an object or a simple type
+  // Distinction if this is an object or a simple type.
+  // Tolerant mode: instead of throwing when a node declares no recognizable
+  // type, warn and render it as a free-form value. The allow-list is widened
+  // beyond `type`/`oneOf`/`anyOf` to also accept the constructs the renderer
+  // can already handle (`$ref`, `allOf`, `const`, `enum`, `if`/`then`/`else`).
   if (
     !jsonSchemaObject.type &&
     !jsonSchemaObject.oneOf &&
     !jsonSchemaObject.anyOf &&
+    !jsonSchemaObject.allOf &&
+    !jsonSchemaObject.$ref &&
+    jsonSchemaObject.const === undefined &&
+    !jsonSchemaObject.enum &&
+    !jsonSchemaObject.if &&
     !castedJsonSchemaObject["x-ref-to-doc"]
   ) {
-    throw new Error(`Schema Object must have a "type" keyword! ${JSON.stringify(jsonSchemaObject, null, 2)}`);
+    log.warn(
+      `Schema object "${title}" has no "type" keyword and no recognizable construct; rendered as free-form. Prefer declaring a "type".`,
+    );
+    text += "**Type**: any\n\n";
+    return text;
   }
 
   // Document extensions towards other target documents
@@ -156,13 +169,11 @@ function getTypeColumnText(
     if (text) {
       return text;
     } else {
-      throw new Error(
-        `ERROR: Objects nested in objects are not supported. Please move the inline object to #/definitions and use $ref! Currently at ${JSON.stringify(
-          jsonSchemaObject,
-          null,
-          2,
-        )}`,
-      );
+      // Tolerant mode: the normalization pass hoists inline objects into
+      // #/definitions, so this is rarely reached. If an inline object does slip
+      // through, warn and render a plain "Object" label rather than aborting.
+      log.warn(`Inline nested object encountered where a $ref to #/definitions is preferred; rendered as "Object".`);
+      return "Object";
     }
   }
   //in case it is a primitive type just return it
@@ -175,14 +186,7 @@ function getTypeColumnText(
   }
   //in case it is a anyOf: option 1 | option 2 | option 3 ...
   else if (jsonSchemaObject?.anyOf) {
-    const anyOfReferences: string[] = [];
-    for (const anyOf of jsonSchemaObject.anyOf) {
-      if (!anyOf.$ref) {
-        throw new Error("anyOf needs to use $refs");
-      }
-      anyOfReferences.push(getMdLinkFromRef(anyOf.$ref, jsonSchemaObject, jsonSchemaRoot));
-    }
-    return anyOfReferences.join(" \\| ");
+    return anyOfReferenceHandling(jsonSchemaObject, jsonSchemaRoot);
   }
   //in case it is a oneOf: option 1 | option 2 | option 3 ...
   //TODO: the syntax is exactly the same as anyOf - Is this correct?
@@ -196,20 +200,43 @@ function getTypeColumnText(
     if (text) {
       return text;
     } else {
-      //in no other case than we do not support the type
-      throw new Error(`Could not determine type for\n ${JSON.stringify(jsonSchemaObject, null, 2)}`);
+      // Tolerant mode: render an unrecognized construct as free-form rather than aborting.
+      log.warn(`Could not determine type for a schema node; rendered as "any".`);
+      return "any";
     }
   }
+}
+
+/**
+ * Render a single composition (oneOf/anyOf/allOf) branch as a type label.
+ * Prefers a `$ref` link; tolerates a non-`$ref` inline branch by rendering its
+ * primitive `type`, `const`, or a plain "Object" label (with a warning) instead
+ * of throwing — the normalization pass usually hoists these to `$ref` first.
+ */
+function getBranchTypeText(
+  branch: SpecJsonSchema,
+  parent: SpecJsonSchema,
+  jsonSchemaRoot: SpecJsonSchemaRoot,
+  keyword: "anyOf" | "oneOf" | "allOf",
+): string {
+  if (branch.$ref) {
+    return getMdLinkFromRef(branch.$ref, parent, jsonSchemaRoot);
+  }
+  if (branch.type && branch.type !== "object") {
+    return escapeHtmlChars(String(branch.type));
+  }
+  if (branch.const !== undefined) {
+    return escapeHtmlChars(`"${String(branch.const)}"`);
+  }
+  log.warn(`Inline ${keyword} branch without $ref; rendered as "${branch.type ? String(branch.type) : "Object"}".`);
+  return branch.type ? escapeHtmlChars(String(branch.type)) : "Object";
 }
 
 function anyOfReferenceHandling(jsonSchemaObject: SpecJsonSchema, jsonSchemaRoot: SpecJsonSchemaRoot): string {
   const anyOfReferences: string[] = [];
   if (jsonSchemaObject.anyOf) {
     for (const anyOf of jsonSchemaObject.anyOf) {
-      if (!anyOf.$ref) {
-        throw new Error("anyOf needs to use $refs");
-      }
-      anyOfReferences.push(getMdLinkFromRef(anyOf.$ref, jsonSchemaObject, jsonSchemaRoot));
+      anyOfReferences.push(getBranchTypeText(anyOf, jsonSchemaObject, jsonSchemaRoot, "anyOf"));
     }
     return anyOfReferences.join(" \\| ");
   }
@@ -220,10 +247,7 @@ function oneOfReferenceHandling(jsonSchemaObject: SpecJsonSchema, jsonSchemaRoot
   const oneOfReferences: string[] = [];
   if (jsonSchemaObject.oneOf) {
     for (const oneOf of jsonSchemaObject.oneOf) {
-      if (!oneOf.$ref) {
-        throw new Error("oneOf needs to use $refs");
-      }
-      oneOfReferences.push(getMdLinkFromRef(oneOf.$ref, jsonSchemaObject, jsonSchemaRoot));
+      oneOfReferences.push(getBranchTypeText(oneOf, jsonSchemaObject, jsonSchemaRoot, "oneOf"));
     }
     return oneOfReferences.join(" \\| ");
   }
@@ -242,11 +266,16 @@ function allOfReferenceHandling(
         allOfReferences.push(getMdLinkFromRef(allOf.$ref, jsonSchemaObject, jsonSchemaRoot));
       } else if (allOf.if && allOf.then?.$ref) {
         allOfReferences.push(getMdLinkFromRef(allOf.then.$ref, jsonSchemaObject, jsonSchemaRoot));
+      } else if (allOf.if && allOf.then) {
+        // Tolerant mode: an `if`/`then` conditional that expresses conditional
+        // requiredness (no $ref target) cannot be shown as a type; note it as a
+        // condition rather than aborting. Common in real schemas.
+        log.warn(`allOf if/then conditional (conditional requiredness) is not rendered as a type; skipped.`);
       } else {
-        throw new Error("allOf needs to use $refs or if/then with $ref");
+        allOfReferences.push(getBranchTypeText(allOf, jsonSchemaObject, jsonSchemaRoot, "allOf"));
       }
     }
-    return allOfReferences.join(` \\${bindingSign} `);
+    return allOfReferences.filter(Boolean).join(` \\${bindingSign} `);
   }
   return "";
 }
@@ -486,14 +515,22 @@ export function getObjectDescriptionTable(
     // is this an allOf with if/then where one property of the object is used as a _discriminator_
     // to distinguish the matching schema that should be further validated?
     if (jsonSchemaObject.allOf[0].if && jsonSchemaObject.allOf[0].then) {
-      text += `**Type**: Object(${allOfReferenceHandling(jsonSchemaObject, jsonSchemaRoot)}) <br/>\n`;
+      const conditionalType = allOfReferenceHandling(jsonSchemaObject, jsonSchemaRoot);
+      if (conditionalType) {
+        text += `**Type**: Object(${conditionalType}) <br/>\n`;
+        typeAlreadySet = true;
+      } else {
+        // Tolerant mode: the allOf only expresses conditional requiredness
+        // (if/then with `required`, no $ref target). Surface it as a note and
+        // fall through to the regular property table for `typeAlreadySet`.
+        text += `_This object has conditional requirements (JSON Schema \`if\`/\`then\`); see the source schema for the exact conditions._<br/>\n`;
+      }
     } else {
       // regular allOf handling, create a new type by combining multiple existing types with the '&' operator
       text += `**Type**: Object(${allOfReferenceHandling(jsonSchemaObject, jsonSchemaRoot, "&")}) <br/>\n`;
       // TODO: Consider merging properties of allOf items into the properties table below?
+      typeAlreadySet = true;
     }
-
-    typeAlreadySet = true;
   }
 
   if (jsonSchemaObject.properties || jsonSchemaObject.patternProperties) {
@@ -1070,7 +1107,8 @@ function getOneOfRefDescription(
       if (oneOfItem.$ref) {
         result += `<li><p>${getMdLinkFromRef(oneOfItem.$ref, jsonSchemaObject, jsonSchemaRoot)}</p></li>`;
       } else {
-        throw new Error(`Expected $ref on oneOf item ${JSON.stringify(jsonSchemaObject, null, 2)}`);
+        // Tolerant mode: render an inline (non-$ref) oneOf item as a best-effort label.
+        result += `<li><p>${getBranchTypeText(oneOfItem, jsonSchemaObject, jsonSchemaRoot, "oneOf")}</p></li>`;
       }
       result += suffix;
     }
@@ -1090,8 +1128,12 @@ function getAllOfRefDescription(jsonSchemaObject: SpecJsonSchema, jsonSchemaRoot
     for (const allOfItem of jsonSchemaObject.allOf) {
       if (allOfItem.$ref) {
         result += `<li><p>${getMdLinkFromRef(allOfItem.$ref, jsonSchemaObject, jsonSchemaRoot)}</p></li>`;
+      } else if (allOfItem.if && allOfItem.then) {
+        // Tolerant mode: conditional requiredness, nothing to link.
+        log.warn(`allOf if/then conditional in "${jsonSchemaObject.title}" not rendered as a linked type; skipped.`);
       } else {
-        throw new Error(`Expected $ref on allOf item ${JSON.stringify(jsonSchemaObject, null, 2)}`);
+        // Tolerant mode: render an inline (non-$ref) allOf item as a best-effort label.
+        result += `<li><p>${getBranchTypeText(allOfItem, jsonSchemaObject, jsonSchemaRoot, "allOf")}</p></li>`;
       }
     }
     result += "</ul>";

--- a/src/plugin/mermaidDiagram/generateDiagrams.ts
+++ b/src/plugin/mermaidDiagram/generateDiagrams.ts
@@ -1,5 +1,5 @@
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import type { JSONSchema7 } from "json-schema";
 import { MermaidDiagram } from "./mermaidClass.js";
 

--- a/src/plugin/tabular/generateExcelAndCSVDefinitions.ts
+++ b/src/plugin/tabular/generateExcelAndCSVDefinitions.ts
@@ -1,6 +1,6 @@
 import * as WorkbookPackage from "exceljs";
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import type { JSONSchema7, JSONSchema7Object } from "json-schema";
 import type { SpecJsonSchemaRoot } from "../../generated/spec/spec-v1/types/index.js";
 import { log } from "../../util/log.js";

--- a/src/plugin/ums/convertSpecJsonSchemaToUmsMetadata.ts
+++ b/src/plugin/ums/convertSpecJsonSchemaToUmsMetadata.ts
@@ -4,7 +4,7 @@
 // # TODO: Add ID for the Consumption Bundle (metadata relation)
 
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import _ from "lodash";
 import { log } from "../../util/log.js";
 import type { UmsMetadataOverrides, UmsPluginConfig } from "./configModel.js";

--- a/src/plugin/ums/generateUmsModels.ts
+++ b/src/plugin/ums/generateUmsModels.ts
@@ -1,5 +1,5 @@
 import fs from "fs-extra";
-import yaml from "js-yaml";
+import * as yaml from "js-yaml";
 import { log } from "../../util/log.js";
 import type { UmsPluginConfig } from "./configModel.js";
 import { convertSpecJsonSchemaToUmsMetadata } from "./convertSpecJsonSchemaToUmsMetadata.js";

--- a/src/util/normalizeArbitrarySchema.test.ts
+++ b/src/util/normalizeArbitrarySchema.test.ts
@@ -1,0 +1,128 @@
+import type { SpecJsonSchemaRoot } from "../generated/spec/spec-v1/types/index.js";
+import { normalizeArbitrarySchema } from "./normalizeArbitrarySchema.js";
+
+describe("normalizeArbitrarySchema", () => {
+  it("hoists an inline nested object into #/definitions and replaces it with a $ref", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: {
+        metadata: {
+          type: "object",
+          properties: { name: { type: "string" } },
+        },
+      },
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { schema: result, warnings } = normalizeArbitrarySchema(schema);
+
+    expect(result.properties!.metadata).toEqual({ $ref: "#/definitions/Metadata" });
+    expect(result.definitions!.Metadata).toMatchObject({ type: "object", title: "Metadata" });
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("inline nested object");
+  });
+
+  it("hoists inline array item objects", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: {
+        schedule: {
+          type: "array",
+          items: { type: "object", properties: { cron: { type: "string" } } },
+        },
+      },
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { schema: result } = normalizeArbitrarySchema(schema);
+    expect(result.properties!.schedule.items).toEqual({ $ref: "#/definitions/ScheduleItems" });
+    expect(result.definitions).toHaveProperty("ScheduleItems");
+  });
+
+  it("hoists an inline (non-$ref) oneOf branch that has a shape", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: {
+        value: {
+          oneOf: [{ type: "object", properties: { a: { type: "string" } } }, { type: "string" }],
+        },
+      },
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { schema: result, warnings } = normalizeArbitrarySchema(schema);
+    const branches = result.properties!.value.oneOf!;
+    // The object branch is hoisted to a $ref; the primitive branch is left inline.
+    expect(branches[0]).toEqual({ $ref: expect.stringContaining("#/definitions/") });
+    expect(branches[1]).toEqual({ type: "string" });
+    expect(warnings.some((w) => w.includes("oneOf branch"))).toBe(true);
+  });
+
+  it("adds a missing object type when object keywords are present", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: {
+        // no `type`, but has `properties` -> should become type: object then hoisted
+        nested: { properties: { x: { type: "string" } } },
+      },
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { schema: result, warnings } = normalizeArbitrarySchema(schema);
+    expect(result.properties!.nested).toEqual({ $ref: expect.stringContaining("#/definitions/") });
+    expect(warnings.some((w) => w.includes('no "type"'))).toBe(true);
+  });
+
+  it("leaves conditional requiredness (allOf if/then, anyOf required) untouched", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: { a: { type: "string" }, b: { type: "string" } },
+      allOf: [{ if: { properties: { a: { const: "x" } } }, then: { required: ["b"] } }],
+      anyOf: [{ required: ["a"] }, { required: ["b"] }],
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { schema: result } = normalizeArbitrarySchema(schema);
+    // The if/then and required-only branches must NOT be hoisted into definitions.
+    expect(result.allOf).toEqual([{ if: { properties: { a: { const: "x" } } }, then: { required: ["b"] } }]);
+    expect(result.anyOf).toEqual([{ required: ["a"] }, { required: ["b"] }]);
+    expect(Object.keys(result.definitions!)).toHaveLength(0);
+  });
+
+  it("normalizes $defs to definitions", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      $defs: { Foo: { type: "object", properties: { x: { type: "string" } } } },
+      properties: { foo: { $ref: "#/$defs/Foo" } },
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { schema: result } = normalizeArbitrarySchema(schema);
+    expect(result.definitions).toHaveProperty("Foo");
+    expect((result as Record<string, unknown>).$defs).toBeUndefined();
+  });
+
+  it("does not mutate the input schema", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: { metadata: { type: "object", properties: { name: { type: "string" } } } },
+    } as unknown as SpecJsonSchemaRoot;
+    const snapshot = JSON.parse(JSON.stringify(schema));
+
+    normalizeArbitrarySchema(schema);
+    expect(schema).toEqual(snapshot);
+  });
+
+  it("passes a convention-clean schema through without warnings", () => {
+    const schema = {
+      type: "object",
+      title: "Root",
+      properties: { metadata: { $ref: "#/definitions/Metadata" } },
+      definitions: { Metadata: { type: "object", title: "Metadata", properties: { name: { type: "string" } } } },
+    } as unknown as SpecJsonSchemaRoot;
+
+    const { warnings } = normalizeArbitrarySchema(schema);
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/src/util/normalizeArbitrarySchema.ts
+++ b/src/util/normalizeArbitrarySchema.ts
@@ -1,0 +1,221 @@
+import type { SpecJsonSchema, SpecJsonSchemaRoot } from "../generated/spec/spec-v1/types/index.js";
+import { log } from "./log.js";
+
+/**
+ * Normalize an arbitrary JSON Schema into the shape the spec-toolkit renderer
+ * and validator expect, WARNING (not throwing) on each deviation from the
+ * strong authoring conventions.
+ *
+ * The renderer (`markdown/generateMarkdownUtils.ts`) and the strict validator
+ * (`util/validation.ts`) assume schemas authored to spec-toolkit's conventions:
+ *   - nested objects live in `#/definitions` and are referenced by `$ref`
+ *     (no inline `type: object` below the root);
+ *   - every `oneOf`/`anyOf`/`allOf` branch is a `$ref`;
+ *   - every schema node declares a `type`.
+ * Real-world and machine-generated schemas routinely break these. Rather than
+ * reject them, this pass rewrites an in-memory COPY into the accepted shape so
+ * documentation can still be generated, and records a warning for each rewrite
+ * so authors can see what was synthesized (and, if they prefer, move it into
+ * `#/definitions` themselves).
+ *
+ * What it does NOT do: it never touches the authored file on disk, and it never
+ * changes the meaning of the schema for validation of instances (the hoisted
+ * definitions are structurally equivalent to the inline ones they replace).
+ *
+ * True unsupported features (constructs that cannot be rendered meaningfully)
+ * are left for the caller to skip; this pass only removes the friction that a
+ * preprocessor can legitimately remove.
+ */
+
+export interface NormalizeResult {
+  schema: SpecJsonSchemaRoot;
+  warnings: string[];
+}
+
+function pascalCase(str: string): string {
+  return String(str)
+    .replace(/[^A-Za-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("");
+}
+
+function uniqueName(base: string, taken: Set<string>): string {
+  let name = base || "Object";
+  let i = 2;
+  while (taken.has(name)) {
+    name = `${base}${i}`;
+    i += 1;
+  }
+  taken.add(name);
+  return name;
+}
+
+/**
+ * Normalize an arbitrary JSON Schema for documentation generation.
+ *
+ * @param schema parsed JSON Schema (never mutated)
+ */
+export function normalizeArbitrarySchema(schema: SpecJsonSchemaRoot): NormalizeResult {
+  // Deep copy; never touch the input.
+  const root = JSON.parse(JSON.stringify(schema)) as SpecJsonSchemaRoot & Record<string, unknown>;
+  // spec-toolkit only understands `definitions` (not `$defs`); consolidate.
+  if ((root as Record<string, unknown>).$defs && !root.definitions) {
+    root.definitions = (root as Record<string, unknown>).$defs as Record<string, SpecJsonSchema>;
+    delete (root as Record<string, unknown>).$defs;
+  }
+  if (!root.definitions) root.definitions = {};
+  const defs = root.definitions as Record<string, SpecJsonSchema>;
+  const taken = new Set<string>(Object.keys(defs));
+  const warnings: string[] = [];
+
+  const warn = (msg: string): void => {
+    warnings.push(msg);
+    log.warn(msg);
+  };
+
+  const isObjectNode = (node: SpecJsonSchema): boolean =>
+    !!node &&
+    typeof node === "object" &&
+    !Array.isArray(node) &&
+    node.type === "object" &&
+    !node.$ref &&
+    !(node as Record<string, unknown>)["x-ref-to-doc"];
+
+  // A node that carries object-ish keywords but forgot `type: object`.
+  const looksLikeObject = (node: SpecJsonSchema): boolean =>
+    !!node &&
+    typeof node === "object" &&
+    !Array.isArray(node) &&
+    !node.type &&
+    !node.$ref &&
+    !node.oneOf &&
+    !node.anyOf &&
+    !node.allOf &&
+    !node.enum &&
+    node.const === undefined &&
+    !(node as Record<string, unknown>)["x-ref-to-doc"] &&
+    (!!node.properties || !!node.patternProperties || node.additionalProperties !== undefined);
+
+  // A composition branch (or subschema) that only expresses constraints
+  // (`required`, `if`/`then`/`else`) with no documentable shape of its own.
+  // These express conditional requiredness, not a type; hoisting them produces
+  // meaningless empty definitions, so we leave them in place and warn instead.
+  const isConstraintOnly = (node: SpecJsonSchema): boolean =>
+    !!node &&
+    typeof node === "object" &&
+    !Array.isArray(node) &&
+    !node.$ref &&
+    !node.type &&
+    !node.properties &&
+    !node.patternProperties &&
+    !node.enum &&
+    node.const === undefined &&
+    (node.required !== undefined || node.if !== undefined || node.then !== undefined || node.else !== undefined);
+
+  const hoist = (node: SpecJsonSchema, pathParts: string[], reason: string): SpecJsonSchema => {
+    const base = node.title ? pascalCase(node.title) : pascalCase(pathParts.filter(Boolean).join(" ")) || "Object";
+    const name = uniqueName(base, taken);
+    if (!node.title) node.title = name; // title lives on the definition, not the $ref
+    defs[name] = node;
+    warn(
+      `Normalized: ${reason} at "${pathParts.join(".") || "(root)"}" hoisted to #/definitions/${name} for documentation generation (authored file unchanged).`,
+    );
+    return { $ref: `#/definitions/${name}` };
+  };
+
+  /**
+   * Walk a schema subtree.
+   * `atRoot` is true only for the top-level schema (allowed to be an object).
+   * `isDefEntry` is true for a direct entry of definitions (already flat).
+   */
+  const walk = (node: SpecJsonSchema, pathParts: string[], atRoot: boolean, isDefEntry: boolean): SpecJsonSchema => {
+    if (!node || typeof node !== "object") return node;
+    if (Array.isArray(node)) {
+      return node.map((item, idx) =>
+        walk(item, pathParts.concat(String(idx)), false, false),
+      ) as unknown as SpecJsonSchema;
+    }
+
+    // Add a missing `type` where the node is clearly an object.
+    if (!atRoot && looksLikeObject(node)) {
+      node.type = "object";
+      warn(
+        `Normalized: node at "${pathParts.join(".") || "(root)"}" has object keywords but no "type"; assumed "object".`,
+      );
+    }
+
+    for (const key of ["properties", "patternProperties", "definitions"] as const) {
+      const container = node[key] as Record<string, SpecJsonSchema> | undefined;
+      if (container && typeof container === "object") {
+        const isDefs = key === "definitions";
+        for (const propName of Object.keys(container)) {
+          container[propName] = walk(container[propName], pathParts.concat(propName), false, isDefs);
+        }
+      }
+    }
+    // Recurse into subschema-bearing keywords that hold documentable shapes.
+    // Note: `if`/`then`/`else` are deliberately NOT recursed into for hoisting —
+    // they express conditional constraints (requiredness), not types to
+    // document, and hoisting their inline objects yields meaningless empty
+    // definitions. They are left untouched for the renderer to note as conditions.
+    for (const key of ["items", "additionalProperties", "contains", "not"] as const) {
+      const child = node[key];
+      if (child && typeof child === "object") {
+        node[key] = walk(child as SpecJsonSchema, pathParts.concat(key), false, false) as never;
+      }
+    }
+    for (const key of ["allOf", "anyOf", "oneOf"] as const) {
+      const branches = node[key];
+      if (Array.isArray(branches)) {
+        node[key] = branches.map((sub: SpecJsonSchema, idx: number) => {
+          // A pure constraint branch (conditional requiredness, no shape) is
+          // left in place; the renderer surfaces it as a condition note.
+          if (isConstraintOnly(sub)) {
+            return sub;
+          }
+          const walked = walk(sub, pathParts.concat(`${key}${idx}`), false, false);
+          // A bare primitive branch (a scalar `type`, or a `const`/`enum` with
+          // no shape of its own) renders inline fine; no need to hoist it.
+          const isBarePrimitive =
+            walked &&
+            typeof walked === "object" &&
+            !Array.isArray(walked) &&
+            !walked.$ref &&
+            !walked.properties &&
+            !walked.patternProperties &&
+            ((typeof walked.type === "string" && walked.type !== "object") ||
+              walked.const !== undefined ||
+              !!walked.enum);
+          // The renderer requires every allOf/anyOf/oneOf branch to be a `$ref`
+          // (except an allOf `if`/`then.$ref` conditional, which it renders).
+          if (
+            walked &&
+            typeof walked === "object" &&
+            !Array.isArray(walked) &&
+            !walked.$ref &&
+            !isBarePrimitive &&
+            !(walked.if && walked.then) &&
+            !isConstraintOnly(walked)
+          ) {
+            return hoist(walked, pathParts.concat(`${key}${idx}`), `inline ${key} branch`);
+          }
+          return walked;
+        }) as never;
+      }
+    }
+
+    // Hoist this node if it is an inline nested object (never the root, never a
+    // direct definitions entry).
+    if (!atRoot && !isDefEntry && isObjectNode(node)) {
+      return hoist(node, pathParts, "inline nested object");
+    }
+    return node;
+  };
+
+  const walked = walk(root as unknown as SpecJsonSchema, [], true, false) as unknown as SpecJsonSchemaRoot;
+  walked.definitions = defs;
+  return { schema: walked, warnings };
+}

--- a/src/util/validation.ts
+++ b/src/util/validation.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { Ajv, type ValidateFunction } from "ajv";
 import addFormats from "ajv-formats";
 import fs from "fs-extra";
@@ -52,7 +53,11 @@ export function validateSpecJsonSchema(jsonSchema: SpecJsonSchemaRoot, jsonSchem
 
   result.errors.push(...validateJsonSchema(jsonSchema, jsonSchemaFilePath));
 
-  result.errors.push(...validateRefLinks(jsonSchema, jsonSchemaFilePath));
+  // Tolerant mode: non-conventional $ref shapes (not `#/definitions/<name>`) are
+  // reported as warnings rather than hard errors. The normalization pass rewrites
+  // arbitrary schemas into the conventional shape before this runs, so surviving
+  // deviations are surfaced without aborting documentation generation.
+  result.warnings.push(...validateRefLinks(jsonSchema, jsonSchemaFilePath));
 
   for (const error of result.errors) {
     log.error(`[${error.context}] ${error.message}`);
@@ -95,7 +100,14 @@ export function validateJsonSchema(
 ): ValidationResultEntry[] {
   const errors: ValidationResultEntry[] = [];
 
-  const jsonSchemaMeta = fs.readJSONSync("./node_modules/ajv/lib/refs/json-schema-draft-07.json") as SpecJsonSchemaRoot;
+  // Resolve the ajv draft-07 meta-schema relative to the installed `ajv`
+  // package rather than the current working directory, so the tool works no
+  // matter where it is invoked from (previously a hardcoded
+  // `./node_modules/ajv/...` path that only resolved from the repo root).
+  const require = createRequire(import.meta.url);
+  const jsonSchemaMeta = fs.readJSONSync(
+    require.resolve("ajv/lib/refs/json-schema-draft-07.json"),
+  ) as SpecJsonSchemaRoot;
   delete jsonSchemaMeta.$id;
 
   const validateMetaSchema = getJsonSchemaValidator(jsonSchemaMeta);


### PR DESCRIPTION
**WIP / draft.** Makes the Markdown doc generator tolerant of JSON Schemas that break the strong authoring conventions (inline nested objects, non-$ref `oneOf`/`anyOf`/`allOf` branches, missing `type`, `if`/`then`/`else`): a new `normalizeArbitrarySchema` pass hoists/normalizes in memory and **warns** instead of throwing; TS-type generation for a schema `json-schema-to-typescript` can't handle is skipped, not fatal. Also resolves the ajv draft-07 ref and `-c`/source paths independent of CWD.

Motivation: needed for the CPA Schema Registry, which documents arbitrary team-authored schemas. Convention-clean schemas are unaffected. Opening as draft to gather feedback on approach before finalizing.